### PR TITLE
Add serialization to External Account Binding

### DIFF
--- a/tests/fixtures/external-binding.json
+++ b/tests/fixtures/external-binding.json
@@ -1,0 +1,5 @@
+{
+    "protected": "eyJhbGciOiJIUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyIiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS8ifQ",
+    "payload": "eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6ImhsaHdUTmk0LTdsQU9JdmY0eWtnNmRiOE9Qb3Nyb2NWUndSQzE0Y1dnX3ciLCJ5IjoiczVBcTFBQTZHNmFMVzRKT0R5WXhPc1d0UXpWVTYwWHhIVDZ1T3NIZFJkMCJ9",
+    "signature": "lbkkwi9p6_yvMg_7T3ZLAOSCbjETSkOZYQY1m15h-n8"
+}


### PR DESCRIPTION
This allows the raw account data to be serialized and deserialized
easily, with a base64 encoded key value transparently handled.
