### PR TITLE
Add header support to yacme protocol

### DIFF
--- a/src/protocol/errors.rs
+++ b/src/protocol/errors.rs
@@ -26,7 +26,7 @@ pub enum AcmeError {
     JsonSerialize(#[source] serde_json::Error),
 
     /// An error occured while trying decode a PEM binary in a response.
-    #[error("An error occured while deserializing a PEM binary: {0}")]
+    #[error("An error occured while deserializing a PEM document: {0}")]
     PemDecodeError(#[from] pem_rfc7468::Error),
 
     /// An error occured while trying decode a DER binary in a response.

--- a/src/protocol/jose.rs
+++ b/src/protocol/jose.rs
@@ -57,6 +57,12 @@ impl From<String> for Nonce {
     }
 }
 
+impl From<&str> for Nonce {
+    fn from(value: &str) -> Self {
+        Nonce(value.to_string())
+    }
+}
+
 /// Identifier used by ACME servers for registered accounts
 ///
 /// Internally, RFC 8885 specifies that this should be the `GET` resource URL

--- a/src/service/order.rs
+++ b/src/service/order.rs
@@ -16,6 +16,8 @@ use chrono::{DateTime, Utc};
 
 use super::{account::Account, authorization::Authorization, client::Client};
 
+const CONTENT_PEM_CHAIN: &str = "application/pem-certificate-chain";
+
 /// Order for a certificate for a set of identifiers.
 #[derive(Debug)]
 pub struct Order<'a> {
@@ -173,7 +175,11 @@ impl<'a> Order<'a> {
         let order_info = &self.data;
         let Some(url) = order_info.certificate() else { return Err(AcmeError::NotReady("certificate")) };
 
-        let request = Request::get(url.clone(), self.account().request_key());
+        let mut request = Request::get(url.clone(), self.account().request_key());
+
+        request
+            .headers_mut()
+            .insert(http::header::ACCEPT, CONTENT_PEM_CHAIN.parse().unwrap());
         let certificate: Response<CertificateChain> = self.client().execute(request).await?;
 
         Ok(certificate.into_inner())


### PR DESCRIPTION
Arbitrary headers can be added to the request via the protocol Request object,
but they will not override the provided CONTENT_TYPE header (since the content
of a JOSE request must be JOSE)

Also sets ACCEPT header on certificate download, so that a PEM chain is returned.
