### PR TITLE
Surface ACME challenge error documents

### DIFF
--- a/examples/low-level/pebble-schema.rs
+++ b/examples/low-level/pebble-schema.rs
@@ -191,7 +191,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let challenge = client
                 .execute::<_, Challenge>(Request::post(
-                    ChallengeReadyRequest::default(),
+                    ChallengeReadyRequest,
                     challenge.url(),
                     account_key.clone(),
                 ))

--- a/src/key/cert.rs
+++ b/src/key/cert.rs
@@ -151,7 +151,7 @@ impl CertificateSigningRequest {
         // Include the extension value in the set of extensions to be included
         // with the X.509 attribute
         let mut values = SetOfVec::new();
-        values.add(encoded_extensions).unwrap();
+        values.insert(encoded_extensions).unwrap();
 
         let attr = x509_cert::attr::Attribute {
             oid: const_oid::db::rfc5912::ID_EXTENSION_REQ,
@@ -160,7 +160,7 @@ impl CertificateSigningRequest {
 
         // Add the extension attribute as the only attribute attached to this CSR
         let mut attributes = SetOfVec::new();
-        attributes.add(attr).unwrap();
+        attributes.insert(attr).unwrap();
 
         // Create the CSR info, which will be signed once encoded in DER
         let csr_info = x509_cert::request::CertReqInfo {


### PR DESCRIPTION
When a challenge becomes invalid, surfacing the error document will help
identify the problem, especially while waiting for a challenge to resolve.
