### PR TITLE
Don't run Actions on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
       - synchronize
       - edited
     branches: [main]
-  push:
-    branches: [main]
 
 name: CI
 


### PR DESCRIPTION
This will be covered by merging PRs since we have branch protection.