### PR TITLE
chore: Release yacme version 4.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yacme"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2021"
 authors = ["Alex Rudy <opensource@alexrudy.net>"]
 license = "MIT"


### PR DESCRIPTION
New features:

- Improved x.509 support using RustCrypto native traits.