### PR TITLE
chore: Release yacme version 4.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yacme"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 authors = ["Alex Rudy <opensource@alexrudy.net>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0.4", features = ["serde"] }
 const-oid = { version = "0.9", features = ["db"] }
 der = { version = "0.7", features = ["std", "pem", "oid"] }
 http = { version = "0.2", optional = true }
-jaws = { version = "0.7" }
+jaws = { version = "0.8" }
 lazy_static = { version = "1", optional = true }
 mime = "0.3"
 pem-rfc7468 = { version = "0.7", features = ["std"] }


### PR DESCRIPTION
Bumps the version of JAWS to allow object-safe trait usage.