### PR TITLE
chore: Release yacme version 5.0.0-alpha.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tracing = { version = "0.1" }
 x509-cert = { version = "0.2", features = ["pem", "std"] }
 
 [dependencies.jaws]
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 features = ["ecdsa", "p256", "rsa", "hmac"]
 
 [dependencies.reqwest]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yacme"
-version = "5.0.0-alpha.1"
+version = "5.0.0-alpha.2"
 edition = "2021"
 authors = ["Alex Rudy <opensource@alexrudy.net>"]
 license = "MIT"


### PR DESCRIPTION
Includes a bump for JAWS to -alpha.2