### PR TITLE
chore/clippy/fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,6 @@ publish = false
 pre-release-hook = ["git", "switch", "-c", "release-{{version}}"]
 push = true
 tag = false
+
+[package.metadata.docs.rs]
+all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
-#![doc = include_str!("../README.md")]
+#![cfg_attr(
+    not(doc),
+    doc = "YACME is an implementation of the [ACME protocol](https://tools.ietf.org/html/rfc8555)."
+)]
+#![cfg_attr(feature = "pebble", doc = include_str!("../README.md"))]
 #![deny(missing_docs)]
 
 pub mod cert;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod service;
 pub mod pebble;
 
 #[cfg(test)]
+#[allow(missing_docs)]
 pub(crate) mod test {
     use std::sync::Arc;
 

--- a/src/pebble.rs
+++ b/src/pebble.rs
@@ -95,7 +95,7 @@ impl PidRc {
     }
 }
 
-impl<'l> LockedPidRc<'l> {
+impl LockedPidRc<'_> {
     fn write(&mut self) {
         self.guard.set_len(0).expect("truncate lock file");
 
@@ -185,7 +185,6 @@ pub struct Pebble {
 
 impl Pebble {
     #[allow(clippy::new_without_default)]
-
     /// Create a new pebble manager instance.
     ///
     /// This effectively acts as a signleton, in that only one pebble

--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -154,7 +154,7 @@ impl AcmeClient {
     }
 
     /// Submit a post request to the ACME provider, using the ACME HTTP JWS
-    #[cfg(all(feature = "trace-requests", not(docs)))]
+    #[cfg(all(feature = "trace-requests", not(doc)))]
     pub async fn post<P, K, L, R>(
         &mut self,
         url: Url,
@@ -172,7 +172,7 @@ impl AcmeClient {
     }
 
     /// Submit a post-as-get request to the ACME provider, using the ACME HTTP JWS
-    #[cfg(all(feature = "trace-requests", not(docs)))]
+    #[cfg(all(feature = "trace-requests", not(doc)))]
     pub async fn get_as_post<K, L, R>(&mut self, url: Url, key: K) -> Result<Response<R>, AcmeError>
     where
         R: Decode + Encode,
@@ -184,7 +184,7 @@ impl AcmeClient {
     }
 
     /// Submit a post request to the ACME provider, using the ACME HTTP JWS
-    #[cfg(any(not(feature = "trace-requests"), docs))]
+    #[cfg(any(not(feature = "trace-requests"), doc))]
     pub async fn post<P, K, L, R>(
         &mut self,
         url: Url,
@@ -202,7 +202,7 @@ impl AcmeClient {
     }
 
     /// Submit a post-as-get request to the ACME provider, using the ACME HTTP JWS
-    #[cfg(any(not(feature = "trace-requests"), docs))]
+    #[cfg(any(not(feature = "trace-requests"), doc))]
     pub async fn get_as_post<K, L, R>(&mut self, url: Url, key: K) -> Result<Response<R>, AcmeError>
     where
         R: Decode,
@@ -219,7 +219,7 @@ impl AcmeClient {
     ///
     /// Request payloads must be serializable, and request responses must implement [`Decode`].
     /// `Decode` is implemented for all types that implement [`serde::Deserialize`].
-    #[cfg(any(not(feature = "trace-requests"), docs))]
+    #[cfg(any(not(feature = "trace-requests"), doc))]
     pub async fn execute<P, K, R>(
         &mut self,
         request: Request<P, K>,
@@ -236,7 +236,7 @@ impl AcmeClient {
     ///
     /// Tracing is done using the [RFC 8885](https://tools.ietf.org/html/rfc8885) format,
     /// via the `tracing` crate, at the `trace` level.
-    #[cfg(all(feature = "trace-requests", not(docs)))]
+    #[cfg(all(feature = "trace-requests", not(doc)))]
     pub async fn execute<P, K, R>(
         &mut self,
         request: Request<P, K>,

--- a/src/protocol/client.rs
+++ b/src/protocol/client.rs
@@ -249,9 +249,8 @@ impl AcmeClient {
         tracing::trace!("REQ: \n{}", request.as_signed().formatted());
         Response::from_decoded_response(self.execute_internal(request).await?)
             .await
-            .map(|r| {
+            .inspect(|r| {
                 tracing::trace!("RES: \n{}", r.formatted());
-                r
             })
     }
 

--- a/src/protocol/fmt.rs
+++ b/src/protocol/fmt.rs
@@ -76,7 +76,7 @@ impl<W> TitleCaseWriter<W> {
 /// as the word separator.
 pub struct TitleCase<'a, T: ?Sized>(&'a T);
 
-impl<'a, T: fmt::Display + ?Sized> fmt::Display for TitleCase<'a, T> {
+impl<T: fmt::Display + ?Sized> fmt::Display for TitleCase<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result {
         let mut writer = TitleCaseWriter::new(f);
         write!(&mut writer, "{}", self.0)
@@ -111,7 +111,7 @@ impl<W> LowerCaseWriter<W> {
 /// also consistent with HTTP/2 and HTTP/3.
 pub struct LowerCase<'a, T: ?Sized>(&'a T);
 
-impl<'a, T: fmt::Display + ?Sized> fmt::Display for LowerCase<'a, T> {
+impl<T: fmt::Display + ?Sized> fmt::Display for LowerCase<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result {
         let mut writer = LowerCaseWriter::new(f);
         write!(&mut writer, "{}", self.0)

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -98,6 +98,7 @@ impl FromStr for Url {
 }
 
 #[cfg(test)]
+#[allow(missing_docs)]
 pub(crate) mod test {
 
     #[macro_export]

--- a/src/protocol/request.rs
+++ b/src/protocol/request.rs
@@ -453,7 +453,7 @@ impl<T, K> Request<T, K> {
 /// [RFC 8885](https://datatracker.ietf.org/doc/html/rfc8555)
 pub struct FormatSignedRequest<'r, T, K>(&'r Request<T, K>, Nonce);
 
-impl<'r, T, K> fmt::JWTFormat for FormatSignedRequest<'r, T, K>
+impl<T, K> fmt::JWTFormat for FormatSignedRequest<'_, T, K>
 where
     T: Serialize,
     K: jaws::algorithms::TokenSigner<jaws::SignatureBytes>,

--- a/src/schema/orders.rs
+++ b/src/schema/orders.rs
@@ -154,7 +154,7 @@ impl FinalizeOrder {
         }
         let signed_csr = csr.sign(key);
 
-        #[cfg(all(feature = "trace-requests", not(docs)))]
+        #[cfg(all(feature = "trace-requests", not(doc)))]
         {
             let doc = signed_csr.to_pem();
             tracing::trace!("CSR: \n{}", doc);
@@ -224,13 +224,12 @@ impl crate::protocol::response::Decode for CertificateChain {
                 Ok(data)
             })
             .collect::<Result<Vec<_>, pem_rfc7468::Error>>()
-            .map_err(|err| {
+            .inspect_err(|&err| {
                 tracing::error!(
                     "Error {} decoding certificate chain {}",
                     err,
                     documents_text
                 );
-                err
             })?;
 
         Ok(CertificateChain {
@@ -238,13 +237,12 @@ impl crate::protocol::response::Decode for CertificateChain {
                 .iter()
                 .map(|doc| x509_cert::Certificate::from_der(doc))
                 .collect::<Result<Vec<_>, der::Error>>()
-                .map_err(|err| {
+                .inspect_err(|&err| {
                     tracing::error!(
                         "Error {} decoding certificate chain as DER: {}",
                         err,
                         documents_text
                     );
-                    err
                 })?,
         })
     }


### PR DESCRIPTION
- **[chore] clippy fixes**
- **[chore] allow missing docs in test modules, and don't compile README when pebble feature is not active.**
